### PR TITLE
Test with NSS in single-user mode

### DIFF
--- a/scripts/add
+++ b/scripts/add
@@ -25,6 +25,9 @@ case $1 in
   'jose')
     GIT_URL='https://github.com/solid/jose'
     ;;
+  'keychain')
+    GIT_URL='https://github.com/solid/keychain'
+    ;;
   'mashlib')
     GIT_URL='https://github.com/solid/mashlib'
     ;;
@@ -58,6 +61,9 @@ case $1 in
     ;;
   'solid-auth-client')
     GIT_URL='https://github.com/solid/solid-auth-client.git'
+    ;;
+  'solid-auth-oidc')
+    GIT_URL='https://github.com/solid/solid-auth-oidc.git'
     ;;
   'solid-auth-tls')
     GIT_URL='https://github.com/solid/solid-auth-tls.git'

--- a/scripts/start
+++ b/scripts/start
@@ -3,4 +3,4 @@
 npx lerna bootstrap --force-local
 
 cd workspaces/node-solid-server
-./bin/solid-test start --root ./data --port 8443 --ssl-key ../privkey.pem --ssl-cert ../fullchain.pem --multiuser
+./bin/solid-test start --root ./data --port 8443 --ssl-key ../privkey.pem --ssl-cert ../fullchain.pem


### PR DESCRIPTION
I recently tried to set up a remote debugging session with @angelo-v and now realise the reason that failed was because of the `--multi-user` default.

I see why you would want to stage multi-user as well, and maybe even more than single-user, since it's probably used at least as frequently in production (solid.community and inrupt.net both run it), but for testing the client-side stack, I think it's easier to use single-user mode, especially now that Chrome changed [how it handles self-signed certs](https://stackoverflow.com/questions/7580508/getting-chrome-to-accept-self-signed-localhost-certificate).